### PR TITLE
Fix missing code generation  for custom data annotation attributes

### DIFF
--- a/EFCore.VisualBasic/EFCore.VisualBasic.vbproj
+++ b/EFCore.VisualBasic/EFCore.VisualBasic.vbproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0-preview.6.21309.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0-preview.7.21325.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>all</IncludeAssets>
     </PackageReference>

--- a/EFCore.VisualBasic/Migrations/Design/VisualBasicSnapshotGenerator.vb
+++ b/EFCore.VisualBasic/Migrations/Design/VisualBasicSnapshotGenerator.vb
@@ -1048,11 +1048,18 @@ Namespace Migrations.Design
             stringBuilder.
                 Append(builderName).
                 Append(".HasCheckConstraint(").
-                Append(VBCode.Literal(checkConstraint.Name)).
+                Append(VBCode.Literal(checkConstraint.ModelName)).
                 Append(", ").
-                Append(VBCode.Literal(checkConstraint.Sql)).
-                AppendLine(")")
+                Append(VBCode.Literal(checkConstraint.Sql))
 
+            If checkConstraint.Name <> If(checkConstraint.GetDefaultName(), checkConstraint.ModelName) Then
+                stringBuilder.
+                    Append(", Sub(c) c.HasName(").
+                    Append(VBCode.Literal(checkConstraint.Name)).
+                    Append(")")
+            End If
+
+            stringBuilder.AppendLine(")")
         End Sub
 
         ''' <summary>

--- a/EFCore.VisualBasic/Scaffolding/Internal/VisualBasicEntityTypeGenerator.vb
+++ b/EFCore.VisualBasic/Scaffolding/Internal/VisualBasicEntityTypeGenerator.vb
@@ -116,6 +116,7 @@ Namespace Scaffolding.Internal
                 For Each argument In attribute.Arguments
                     attributeWriter1.AddParameter(_code.UnknownLiteral(argument))
                 Next
+                _sb.AppendLine(attributeWriter1.ToString())
             Next
         End Sub
 
@@ -230,6 +231,7 @@ Namespace Scaffolding.Internal
                 For Each argument In attribute.Arguments
                     attributeWriter1.AddParameter(_code.UnknownLiteral(argument))
                 Next
+                _sb.AppendLine(attributeWriter1.ToString())
             Next
         End Sub
 

--- a/Sandbox/Sandbox.vbproj
+++ b/Sandbox/Sandbox.vbproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0-preview.6.21309.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0-preview.6.21309.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0-preview.7.21325.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0-preview.7.21325.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Test/EFCore.Design.Tests.Shared/EFCore.Design.Tests.Shared.csproj
+++ b/Test/EFCore.Design.Tests.Shared/EFCore.Design.Tests.Shared.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0-preview.6.21309.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.0-preview.6.21309.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0-preview.7.21325.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.0-preview.7.21325.1" />
   </ItemGroup>
 
 </Project>

--- a/Test/EFCore.VisualBasic.Test/EFCore.VisualBasic.Test.vbproj
+++ b/Test/EFCore.VisualBasic.Test/EFCore.VisualBasic.Test.vbproj
@@ -19,14 +19,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.10.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0-preview.6.21309.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0-preview.7.21325.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>all</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0-preview.6.21309.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="6.0.0-preview.6.21309.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0-preview.6.21309.9" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0-preview.6.21314.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0-preview.7.21325.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="6.0.0-preview.7.21325.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0-preview.7.21325.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0-preview.7.21326.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">

--- a/Test/EFCore.VisualBasic.Test/Scaffolding/Internal/VisualBasicDbContextGeneratorTest.vb
+++ b/Test/EFCore.VisualBasic.Test/Scaffolding/Internal/VisualBasicDbContextGeneratorTest.vb
@@ -10,6 +10,7 @@ Imports Xunit
 
 Namespace Scaffolding.Internal
     Public Class VisualBasicDbContextGeneratorTest
+        Inherits VisualBasicModelCodeGeneratorTestBase
 
         <ConditionalFact>
         Public Sub Empty_model()
@@ -1037,13 +1038,6 @@ End Namespace
                 Return New MethodCallCodeFragment("SetContextOption")
             End Function
         End Class
-
-        Private Shared Sub AssertFileContents(
-            expectedCode As String,
-            file As ScaffoldedFile)
-
-            Assert.Equal(expectedCode, file.Code, ignoreLineEndingDifferences:=True)
-        End Sub
 
     End Class
 

--- a/Test/EFCore.VisualBasic.Test/Scaffolding/Internal/VisualBasicModelCodeGeneratorTestBase.vb
+++ b/Test/EFCore.VisualBasic.Test/Scaffolding/Internal/VisualBasicModelCodeGeneratorTestBase.vb
@@ -1,41 +1,36 @@
 ﻿Imports EntityFrameworkCore.VisualBasic.Design
-Imports EntityFrameworkCore.VisualBasic.Design.Internal
-Imports EntityFrameworkCore.VisualBasic.Scaffolding.Internal
 Imports EntityFrameworkCore.VisualBasic.TestUtilities
 Imports Microsoft.EntityFrameworkCore
-Imports Microsoft.EntityFrameworkCore.Design
 Imports Microsoft.EntityFrameworkCore.Design.Internal
 Imports Microsoft.EntityFrameworkCore.Infrastructure
 Imports Microsoft.EntityFrameworkCore.Metadata
 Imports Microsoft.EntityFrameworkCore.Metadata.Internal
 Imports Microsoft.EntityFrameworkCore.Scaffolding
-Imports Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
 Imports Microsoft.Extensions.DependencyInjection
+Imports Xunit
 
-Friend Module VisualBasicModelCodeGeneratorTestBase
+Public MustInherit Class VisualBasicModelCodeGeneratorTestBase
 
     Sub Test(buildModel As Action(Of ModelBuilder),
              options As ModelCodeGenerationOptions,
              assertScaffold As Action(Of ScaffoldedModel),
-             assertModel As Action(Of IModel))
+             assertModel As Action(Of IModel),
+             Optional skipBuild As Boolean = False)
 
-        Dim mb = SqlServerTestHelpers.Instance.CreateConventionBuilder()
+        Dim designServices = New ServiceCollection()
+        AddModelServices(designServices)
+
+        Dim mb = SqlServerTestHelpers.Instance.CreateConventionBuilder(customServices:=designServices)
         mb.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersion)
         buildModel(mb)
 
-        Call mb.Model.GetEntityTypeErrors()
-
         Dim model = mb.FinalizeModel(designTime:=True, skipValidation:=True)
 
-        Dim services = New ServiceCollection
-        services.AddEntityFrameworkDesignTimeServices()
-        services.AddSingleton(Of IVisualBasicHelper, VisualBasicHelper)()
-        services.AddSingleton(Of IModelCodeGenerator, VisualBasicModelGenerator)()
+        Dim services = CreateServices()
+        AddScaffoldingServices(services)
 
-        Dim sqlSrvD = New SqlServerDesignTimeServices
-        sqlSrvD.ConfigureDesignTimeServices(services)
-
-        Dim generator = services.BuildServiceProvider().GetRequiredService(Of IModelCodeGenerator)()
+        Dim generator = services.BuildServiceProvider().
+                                 GetRequiredService(Of IModelCodeGenerator)()
 
         options.ModelNamespace = If(options.ModelNamespace, "TestNamespace")
         options.ContextNamespace = If(options.ContextNamespace, options.ModelNamespace)
@@ -68,14 +63,16 @@ Friend Module VisualBasicModelCodeGeneratorTestBase
                         ToDictionary(Function(f) f.Path, Function(f) f.Code)
         }
 
-        Dim assembly = build.BuildInMemory()
-        Dim dbContextNameSpace = assembly.ExportedTypes.FirstOrDefault(Function(t) t.Name = options.ContextName)?.FullName
+        If Not skipBuild Then
+            Dim assembly = build.BuildInMemory()
+            Dim dbContextNameSpace = assembly.ExportedTypes.FirstOrDefault(Function(t) t.Name = options.ContextName)?.FullName
 
-        Dim context = CType(assembly.CreateInstance(dbContextNameSpace), DbContext)
+            Dim context = CType(assembly.CreateInstance(dbContextNameSpace), DbContext)
 
-        If assertModel IsNot Nothing Then
-            Dim compiledModel = context.GetService(Of IDesignTimeModel)().Model
-            assertModel(compiledModel)
+            If assertModel IsNot Nothing Then
+                Dim compiledModel = context.GetService(Of IDesignTimeModel)().Model
+                assertModel(compiledModel)
+            End If
         End If
     End Sub
 
@@ -91,4 +88,15 @@ Friend Module VisualBasicModelCodeGeneratorTestBase
         Return services
     End Function
 
-End Module
+    Protected Overridable Sub AddModelServices(services As IServiceCollection)
+    End Sub
+
+    Protected Overridable Sub AddScaffoldingServices(services As IServiceCollection)
+    End Sub
+
+    Protected Shared Sub AssertFileContents(expectedCode As String,
+                                            file As ScaffoldedFile)
+
+        Assert.Equal(expectedCode, file.Code, ignoreLineEndingDifferences:=True)
+    End Sub
+End Class


### PR DESCRIPTION
Fix missing code generation output for custom data annotation attributes. (We had the same problem as the [C# version](https://github.com/dotnet/efcore/pull/25128)).

Usable with daily version 7.21325.1 of EfCore.