### PR TITLE
Fixes for v7

### DIFF
--- a/EFCore.VisualBasic.Templates/templates/ef-templates/CodeTemplates/EFCore/DbContext.t4
+++ b/EFCore.VisualBasic.Templates/templates/ef-templates/CodeTemplates/EFCore/DbContext.t4
@@ -182,8 +182,7 @@ Namespace <#= FileNamespaceIdentifier #>
         foreach (var property in entityType.GetProperties())
         {
             var propertyFluentApiCalls = property.GetFluentApiCalls(annotationCodeGenerator)
-                ?.FilterChain(c => !(Options.UseDataAnnotations && c.IsHandledByDataAnnotations)
-                    && !(c.Method == "IsRequired" && Options.UseNullableReferenceTypes && !property.ClrType.IsValueType));
+                ?.FilterChain(c => !(Options.UseDataAnnotations && c.IsHandledByDataAnnotations));
 
             if (propertyFluentApiCalls == null)
             {
@@ -220,7 +219,7 @@ Namespace <#= FileNamespaceIdentifier #>
                 WriteLine("");
             }
 #>
-                    entity.HasOne(Function(d) d.<#= foreignKey.DependentToPrincipal.Name #>).<#= foreignKey.IsUnique ? "WithOne" : "WithMany" #>(Function(p) p.<#= foreignKey.PrincipalToDependent.Name #>)<#= code.Fragment(foreignKeyFluentApiCalls, indent: 6) #>
+                    entity.HasOne(Function(d) d.<#= foreignKey.DependentToPrincipal.Name #>).<#= foreignKey.IsUnique ? "WithOne" : "WithMany" #>(<#= foreignKey.PrincipalToDependent != null ? $"Function(p) p.{foreignKey.PrincipalToDependent.Name}" : "" #>)<#= code.Fragment(foreignKeyFluentApiCalls, indent: 6) #>
 <#
             anyEntityTypeConfiguration = true;
         }
@@ -251,8 +250,8 @@ Namespace <#= FileNamespaceIdentifier #>
                     entity.HasMany(Function(d) d.<#= skipNavigation.Name #>).WithMany(Function(p) p.<#= skipNavigation.Inverse.Name #>).
                         UsingEntity(Of Dictionary(Of String, Object))(
                             <#= code.Literal(joinEntityType.Name) #>,
-                            Function(r) r.HasOne(Of <#= right.PrincipalEntityType.Name #>)().WithMany()<#= code.Fragment(rightFluentApiCalls, indent: 7) #>,
-                            Function(l) l.HasOne(Of <#= left.PrincipalEntityType.Name #>)().WithMany()<#= code.Fragment(leftFluentApiCalls, indent: 7) #>,
+                            Function(r) r.HasOne(Of <#= right.PrincipalEntityType.Name #>)().WithMany()<#= code.Fragment(rightFluentApiCalls, indent: 8) #>,
+                            Function(l) l.HasOne(Of <#= left.PrincipalEntityType.Name #>)().WithMany()<#= code.Fragment(leftFluentApiCalls, indent: 8) #>,
                             Sub(j)
 <#
             var joinKey = joinEntityType.FindPrimaryKey();
@@ -284,6 +283,20 @@ Namespace <#= FileNamespaceIdentifier #>
                 }
 #>
                                 j.HasIndex(<#= code.Literal(index.Properties.Select((e) => e.Name).ToArray()) #>, <#= code.Literal(index.GetDatabaseName()) #>)<#= code.Fragment(indexFluentApiCalls, indent: 8) #>
+<#
+            }
+
+            foreach (var property in joinEntityType.GetProperties())
+            {
+                var propertyFluentApiCalls = property.GetFluentApiCalls(annotationCodeGenerator);
+                if (propertyFluentApiCalls == null)
+                {
+                    continue;
+                }
+
+                importsList.AddRange(propertyFluentApiCalls.GetRequiredUsings());
+#>
+                                j.IndexerProperty(Of <#= code.Reference(property.ClrType) #>)(<#= code.Literal(property.Name) #>)<#= code.Fragment(propertyFluentApiCalls, indent: 8) #>
 <#
             }
 #>

--- a/EFCore.VisualBasic.Templates/templates/ef-templates/CodeTemplates/EFCore/EntityType.t4
+++ b/EFCore.VisualBasic.Templates/templates/ef-templates/CodeTemplates/EFCore/EntityType.t4
@@ -90,8 +90,7 @@ Namespace <#= FileNamespaceIdentifier #>
 
         if (Options.UseDataAnnotations)
         {
-            var dataAnnotations = property.GetDataAnnotations(annotationCodeGenerator)
-                .Where(a => !(a.Type == typeof(RequiredAttribute) && Options.UseNullableReferenceTypes && !property.ClrType.IsValueType));
+            var dataAnnotations = property.GetDataAnnotations(annotationCodeGenerator);
 
             foreach (var dataAnnotation in dataAnnotations)
             {
@@ -131,8 +130,6 @@ Namespace <#= FileNamespaceIdentifier #>
         }
         else
         {
-            var needsNullable = Options.UseNullableReferenceTypes && !(navigation.ForeignKey.IsRequired && navigation.IsOnDependent);
-            var needsInitializer = Options.UseNullableReferenceTypes && navigation.ForeignKey.IsRequired && navigation.IsOnDependent;
 #>
         Public Overridable Property <#= code.Identifier(navigation.Name) #> As <#= targetType #>
 <#

--- a/EFCore.VisualBasic/EFCore.VisualBasic.vbproj
+++ b/EFCore.VisualBasic/EFCore.VisualBasic.vbproj
@@ -45,16 +45,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="7.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="7.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.2">
       <IncludeAssets>all</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="7.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="7.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/EFCore.VisualBasic/Scaffolding/Internal/VisualBasicDbContextGenerator.tt
+++ b/EFCore.VisualBasic/Scaffolding/Internal/VisualBasicDbContextGenerator.tt
@@ -161,8 +161,7 @@ Namespace <#= FileNamespaceIdentifier #>
         Dim firstProperty = True
         For Each prop in entityType.GetProperties()
             Dim propertyFluentApiCalls = prop.GetFluentApiCalls(annotationCodeGenerator)?.
-                                              FilterChain(Function(c) Not (Options.UseDataAnnotations AndAlso c.IsHandledByDataAnnotations) AndAlso
-                                              Not (c.Method = "IsRequired" AndAlso Options.UseNullableReferenceTypes AndAlso Not prop.ClrType.IsValueType))
+                                              FilterChain(Function(c) Not (Options.UseDataAnnotations AndAlso c.IsHandledByDataAnnotations))
 
             If propertyFluentApiCalls Is Nothing Then
                 Continue For
@@ -194,7 +193,7 @@ Namespace <#= FileNamespaceIdentifier #>
                 WriteLine("")
             End If
 #>
-                    entity.HasOne(Function(d) d.<#= foreignKey.DependentToPrincipal.Name #>).<#= If(foreignKey.IsUnique, "WithOne", "WithMany") #>(Function(p) p.<#= foreignKey.PrincipalToDependent.Name #>)<#= code.Fragment(foreignKeyFluentApiCalls, indent:=6) #>
+                    entity.HasOne(Function(d) d.<#= foreignKey.DependentToPrincipal.Name #>).<#= If(foreignKey.IsUnique, "WithOne", "WithMany") #>(<#= If(foreignKey.PrincipalToDependent IsNot Nothing, $"Function(p) p.{foreignKey.PrincipalToDependent.Name}", "") #>)<#= code.Fragment(foreignKeyFluentApiCalls, indent:=6) #>
 <#
             anyEntityTypeConfiguration = True
         Next
@@ -221,8 +220,8 @@ Namespace <#= FileNamespaceIdentifier #>
                     entity.HasMany(Function(d) d.<#= skipNavigation.Name #>).WithMany(Function(p) p.<#= skipNavigation.Inverse.Name #>).
                         UsingEntity(Of Dictionary(Of String, Object))(
                             <#= code.Literal(joinEntityType.Name) #>,
-                            Function(r) r.HasOne(Of <#= right.PrincipalEntityType.Name #>)().WithMany()<#= code.Fragment(rightFluentApiCalls, indent:=7) #>,
-                            Function(l) l.HasOne(Of <#= left.PrincipalEntityType.Name #>)().WithMany()<#= code.Fragment(leftFluentApiCalls, indent:=7) #>,
+                            Function(r) r.HasOne(Of <#= right.PrincipalEntityType.Name #>)().WithMany()<#= code.Fragment(rightFluentApiCalls, indent:=8) #>,
+                            Function(l) l.HasOne(Of <#= left.PrincipalEntityType.Name #>)().WithMany()<#= code.Fragment(leftFluentApiCalls, indent:=8) #>,
                             Sub(j)
 <#
             Dim joinKey = joinEntityType.FindPrimaryKey()
@@ -250,6 +249,18 @@ Namespace <#= FileNamespaceIdentifier #>
                 End If
 #>
                                 j.HasIndex(<#= code.Literal(index.Properties.Select(Function(e) e.Name).ToArray()) #>, <#= code.Literal(index.GetDatabaseName()) #>)<#= code.Fragment(indexFluentApiCalls, indent:=8) #>
+<#
+            Next
+
+            For Each prop in joinEntityType.GetProperties()
+                Dim propertyFluentApiCalls = prop.GetFluentApiCalls(annotationCodeGenerator)
+                If propertyFluentApiCalls Is Nothing Then
+                    Continue For
+                End If
+
+                importsList.AddRange(propertyFluentApiCalls.GetRequiredUsings())
+#>
+                                j.IndexerProperty(Of <#= code.Reference(prop.ClrType) #>)(<#= code.Literal(prop.Name) #>)<#= code.Fragment(propertyFluentApiCalls, indent:=8) #>
 <#
             Next
 #>

--- a/EFCore.VisualBasic/Scaffolding/Internal/VisualBasicEntityTypeGenerator.tt
+++ b/EFCore.VisualBasic/Scaffolding/Internal/VisualBasicEntityTypeGenerator.tt
@@ -76,10 +76,8 @@ Namespace <#= FileNamespaceIdentifier #>
         End If
 
         If Options.UseDataAnnotations Then
-            Dim dataAnnotations = prop.GetDataAnnotations(annotationCodeGenerator).
-                                        Where(Function(a) Not (a.Type = GetType(RequiredAttribute) AndAlso 
-                                                          Options.UseNullableReferenceTypes AndAlso 
-                                                          Not prop.ClrType.IsValueType))
+            Dim dataAnnotations = prop.GetDataAnnotations(annotationCodeGenerator)
+
             For Each dataAnnotation in dataAnnotations
 #>
         <#= code.Fragment(dataAnnotation) #>

--- a/EFCore.VisualBasic/Scaffolding/Internal/VisualBasicEntityTypeGenerator.vb
+++ b/EFCore.VisualBasic/Scaffolding/Internal/VisualBasicEntityTypeGenerator.vb
@@ -96,10 +96,8 @@ Namespace Scaffolding.Internal
         End If
 
         If Options.UseDataAnnotations Then
-            Dim dataAnnotations = prop.GetDataAnnotations(annotationCodeGenerator).
-                                        Where(Function(a) Not (a.Type = GetType(RequiredAttribute) AndAlso 
-                                                          Options.UseNullableReferenceTypes AndAlso 
-                                                          Not prop.ClrType.IsValueType))
+            Dim dataAnnotations = prop.GetDataAnnotations(annotationCodeGenerator)
+
             For Each dataAnnotation in dataAnnotations
 
             Me.Write("        ")

--- a/EFCore.VisualBasic/VisualBasicUtilities.vb
+++ b/EFCore.VisualBasic/VisualBasicUtilities.vb
@@ -243,22 +243,6 @@ Public Module VisualBasicUtilities
                category = UnicodeCategory.LetterNumber
     End Function
 
-    Public Function RemoveRootNamespaceFromNamespace(rootNamespace As String, FullNamespace As String) As String
-        If String.IsNullOrWhiteSpace(rootNamespace) Then Return FullNamespace
-
-        Dim finalNamespace = FullNamespace
-
-        If FullNamespace.StartsWith(rootNamespace, StringComparison.OrdinalIgnoreCase) Then
-            If FullNamespace.Length > rootNamespace.Length Then
-                finalNamespace = FullNamespace.Substring(rootNamespace.Length + 1)
-            Else
-                finalNamespace = String.Empty
-            End If
-        End If
-
-        Return finalNamespace
-    End Function
-
 #Region "Guards"
     <DebuggerStepThrough>
     Public Function NotNull(Of T)(value As T, parameterName As String) As T

--- a/Sandbox/Sandbox.vbproj
+++ b/Sandbox/Sandbox.vbproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Test/EFCore.Design.Tests.Shared/EFCore.Design.Tests.Shared.csproj
+++ b/Test/EFCore.Design.Tests.Shared/EFCore.Design.Tests.Shared.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="7.0.2" />
   </ItemGroup>
 
 </Project>

--- a/Test/EFCore.VisualBasic.Test/EFCore.VisualBasic.Test.vbproj
+++ b/Test/EFCore.VisualBasic.Test/EFCore.VisualBasic.Test.vbproj
@@ -24,18 +24,18 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.2">
       <IncludeAssets>all</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="7.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Handle FK on keyless entity type
- Fix code for EF6 many-to-many pattern
- Fix missing HasForeignKey when principal key is an alternate key
- Ignore NRT option in templates

part of #87 